### PR TITLE
Temporarily add a patches to be applied to generated protos.

### DIFF
--- a/PATCHES/README.md
+++ b/PATCHES/README.md
@@ -1,0 +1,11 @@
+# Patches applied to generated Hercules Modules
+
+This directory contains patches that are automatically applied to the generated
+hercules protobuf files for the OpenConfig hercules modules. They reflect
+temporary changes that are required before upstream code generation fixes are
+updated.
+
+Each patch is enumerated in this file:
+
+ * `imports.patch` -- this patch removes unused imports, it can be removed when
+   ygot issue #432 is resolved.

--- a/PATCHES/imports.patch
+++ b/PATCHES/imports.patch
@@ -1,0 +1,37 @@
+diff --git a/proto/openconfig/enums/enums.proto b/proto/openconfig/enums/enums.proto
+index 4798934..58420c7 100644
+--- a/proto/openconfig/enums/enums.proto
++++ b/proto/openconfig/enums/enums.proto
+@@ -26,7 +26,6 @@ syntax = "proto3";
+ 
+ package openconfig.enums;
+ 
+-import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
+ import "github.com/openconfig/ygot/proto/yext/yext.proto";
+ 
+ // IETFInterfacesInterfaceType represents an enumerated type generated for the YANG identity interface-type.
+diff --git a/proto/openconfig/hercules/hercules.proto b/proto/openconfig/hercules/hercules.proto
+index 06841b5..b52b017 100644
+--- a/proto/openconfig/hercules/hercules.proto
++++ b/proto/openconfig/hercules/hercules.proto
+@@ -26,8 +26,5 @@ syntax = "proto3";
+ 
+ package openconfig.hercules;
+ 
+-import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
+-import "github.com/openconfig/ygot/proto/yext/yext.proto";
+-
+ message Hercules {
+ }
+diff --git a/proto/openconfig/openconfig.proto b/proto/openconfig/openconfig.proto
+index 9c43e27..a270c2d 100644
+--- a/proto/openconfig/openconfig.proto
++++ b/proto/openconfig/openconfig.proto
+@@ -26,7 +26,6 @@ syntax = "proto3";
+ 
+ package openconfig;
+ 
+-import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
+ import "github.com/openconfig/ygot/proto/yext/yext.proto";
+ import "github.com/openconfig/hercules/proto/openconfig/hercules/hercules.proto";
+ import "github.com/openconfig/hercules/proto/openconfig/openconfig_interfaces/openconfig_interfaces.proto";

--- a/proto/generate.sh
+++ b/proto/generate.sh
@@ -62,6 +62,12 @@ go run $GOPATH/src/github.com/openconfig/ygot/proto_generator/protogenerator.go 
   ../yang/openconfig-hercules-interfaces.yang \
   ../yang/openconfig-hercules-platform-node.yang
 rm -rf public yang
+
+for p in `ls $THISDIR/../PATCHES`; do
+  git apply $THISDIR/../PATCHES/$p
+done
+
+
 find . -type d -mindepth 1 | while read l; do (cd $l && go generate); done;
 )
 

--- a/proto/openconfig/enums/enums.proto
+++ b/proto/openconfig/enums/enums.proto
@@ -26,7 +26,6 @@ syntax = "proto3";
 
 package openconfig.enums;
 
-import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
 // IETFInterfacesInterfaceType represents an enumerated type generated for the YANG identity interface-type.

--- a/proto/openconfig/hercules/hercules.proto
+++ b/proto/openconfig/hercules/hercules.proto
@@ -26,8 +26,5 @@ syntax = "proto3";
 
 package openconfig.hercules;
 
-import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
-import "github.com/openconfig/ygot/proto/yext/yext.proto";
-
 message Hercules {
 }

--- a/proto/openconfig/openconfig.proto
+++ b/proto/openconfig/openconfig.proto
@@ -26,7 +26,6 @@ syntax = "proto3";
 
 package openconfig;
 
-import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 import "github.com/openconfig/hercules/proto/openconfig/hercules/hercules.proto";
 import "github.com/openconfig/hercules/proto/openconfig/openconfig_interfaces/openconfig_interfaces.proto";


### PR DESCRIPTION
This PR adds a means for us to temporarily apply patches to the generated
hercules protobufs whilst waiting for upstream tooling changes. Specifically
this allows unused imports to be removed from the generated protos before
the upstream github.com/ygot/issues/432 is resolved.

```
 * (A) PATCHES/*
   - Add patches that are automatically applied to generated protobufs.
 * (M) proto/generate.sh
   - Ensure that patches are applied automatically when protobufs are
     generated.
 * (M) proto/.../*.proto
   - Apply patches to current hercules protobufs.
```